### PR TITLE
Small front end changes on the 'About' page

### DIFF
--- a/badges/templates/about/home.html
+++ b/badges/templates/about/home.html
@@ -67,10 +67,10 @@
             </p>
             <p>If and when you do acquire the Badge, it will appear on your
                 <a href="http://Badges.p2pu.org" target="_blank">Badges.p2pu.org</a>
-                profile page, and you'll be an Expert yourself.&nbsp;
+                profile page, and you'll be an Expert yourself.
                 <a href="http://images2.fanpop.com/images/photos/3800000/Animated-GIFs-flight-of-the-conchords-3809583-412-333.gif?1339094385414" target="_blank">
                     Celebration
-                </a>!&nbsp;
+                </a>!
             </p>
 
             <div id="create-badge">
@@ -152,22 +152,22 @@
                 If you're curious about Badges or P2PU and would like to find out more, here's some info:
 
                 <ul>
-                    <li>Check out the&nbsp;
+                    <li>Check out the
                         <a href="http://info.p2pu.org/2013/01/25/its-the-feedback-silly-p2pus-plan-for-badges/" target="_blank">
                             Pedagogy Behind Badges
                         </a>.<br>
                     </li>
-                    <li>Follow our progress on our&nbsp;
+                    <li>Follow our progress on our
                         <a href="https://trello.com/board/badges/512397c1036058ed1a0034b6" target="_blank">
                             team Trello Board
                         </a>.<br>
                     </li>
-                    <li>Join the&nbsp;
+                    <li>Join the
                         <a href="http://groups.google.com/group/p2pu-community" target="_blank">
                             P2PU Community
-                        </a>&nbsp;to find out what crafty experiments we're up to.<br>
+                        </a>to find out what crafty experiments we're up to.<br>
                     </li>
-                    <li>Contact&nbsp;
+                    <li>Contact
                         <a href="mailto:vanessa@p2pu.org" target="_blank">
                             Vanessa
                         </a>, your humble Mad Learning Scientist.

--- a/badges/templates/landing/home.html
+++ b/badges/templates/landing/home.html
@@ -23,7 +23,7 @@
                         "Expert" and already possess the Badge, award it to someone else.
                     </p>
                     <p>
-                        <a href="http://info.p2pu.org/2013/03/21/get-feedback-on-a-project-you-love-p2pu-launches-a-new-version-of-badges/">
+                        <a href="{% url about %}">
                             Find out more....
                         </a>
                     </p>


### PR DESCRIPTION
Just some small changes in the front end on About page.
- link 'Found out more' on landing page is now connected to 'About' page
- some spaces sneaked in on creation of a page that had to be removed
