### PR TITLE
Fixing email notifications that did not work correctly

### DIFF
--- a/badges/badge/models.py
+++ b/badges/badge/models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from .db import Badge
 from .db import Award
 from .notification_helpers import send_badge_creation_notification
+from .notification_helpers import send_badge_published_notification
 from .notification_helpers import send_badge_awarded_notification
 
 
@@ -136,6 +137,7 @@ def publish_badge(uri):
         badge_db.author_uri,
         reverse('badge_view', args=(badge_db.pk, )),
     )
+    send_badge_published_notification(_badge2dict(badge_db))
     return True
 
 

--- a/badges/badge/notification_helpers.py
+++ b/badges/badge/notification_helpers.py
@@ -15,6 +15,19 @@ def send_badge_creation_notification(badge):
         context=context
     )
 
+def send_badge_published_notification(badge):
+    subject_template = 'emails/badge_published_subject.txt'
+    text_template = 'emails/badge_published.txt'
+    html_template = 'emails/badge_published.html'
+    context = {'badge': fetch_badge_resources(badge)}
+    return send_notification_i18n(
+        badge['author_uri'],
+        subject_template,
+        text_template,
+        html_template,
+        context=context
+    )
+
 
 def send_badge_awarded_notification(badge, expert_uri):
     subject_template = 'emails/badge_awarded_subject.txt'

--- a/badges/badge/views.py
+++ b/badges/badge/views.py
@@ -1,6 +1,6 @@
 from django.core.serializers.json import DjangoJSONEncoder
 from django import http
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.core.urlresolvers import reverse
@@ -70,6 +70,10 @@ def create(request):
 @require_login
 def preview(request, badge_id):
     badge = badge_api.get_badge(badge_api.id2uri(badge_id))
+
+    if badge['published_date']:
+        return HttpResponseRedirect(reverse('badge_view', args=[badge_id]))
+
     fetch_badge_resources(badge)
     user = request.session['user']
     user['is_author'] = _user_is_author(badge, user)

--- a/badges/badges/settings.py
+++ b/badges/badges/settings.py
@@ -207,4 +207,4 @@ ORGANISATION_URL = 'badges.p2pu.org'
 #################################################################
 MANDRILL_API_KEY = ""
 EMAIL_BACKEND = "djrill.mail.backends.djrill.DjrillBackend"
-DEFAULT_FROM_EMAIL = "P2PU Badges Team <badges@p2pu.org>"
+DEFAULT_FROM_EMAIL = "P2PU team <badges@p2pu.org>"

--- a/badges/badges/settings.py
+++ b/badges/badges/settings.py
@@ -207,4 +207,4 @@ ORGANISATION_URL = 'badges.p2pu.org'
 #################################################################
 MANDRILL_API_KEY = ""
 EMAIL_BACKEND = "djrill.mail.backends.djrill.DjrillBackend"
-DEFAULT_FROM_EMAIL = "badges@p2pu.org"
+DEFAULT_FROM_EMAIL = "P2PU Badges Team <badges@p2pu.org>"

--- a/badges/dashboard/templatetags/projects_tags.py
+++ b/badges/dashboard/templatetags/projects_tags.py
@@ -1,5 +1,6 @@
 from django import template
 from django.template.defaultfilters import mark_safe
+from subprocess import Popen, PIPE
 
 register = template.Library()
 
@@ -7,3 +8,17 @@ register = template.Library()
 @register.filter
 def purge_content(value):
     return mark_safe(value.replace('<p>&nbsp;</p>', ''))
+
+@register.filter
+def html2text(value):
+    """
+    Pipes given HTML string into the text browser W3M, which renders it.
+    Rendered text is grabbed from STDOUT and returned.
+    """
+    try:
+        cmd = "w3m -dump -T text/html -O ascii"
+        proc = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE)
+        return proc.communicate(str(value))[0]
+    except OSError:
+        # something bad happened, so just return the input
+        return value

--- a/badges/templates/emails/badge_created.txt
+++ b/badges/templates/emails/badge_created.txt
@@ -1,20 +1,16 @@
-{% load projects_tags %}{% load i18n %}{% blocktrans with title=badge.title decription=badge.description|purge_content requirements=badge.requirements%}
+{% load projects_tags %}{% load i18n %}{% blocktrans with title=badge.title description=badge.description|purge_content requirements=badge.requirements|html2text %}
 Howdy!
 
-Your badge {{ title }} is published, live, and ready-to-go.
+Your badge {{ badge.title }} is created. Woohoo!
 
-{{ title }}
-{{ description }}
-{{ requirements }}
+* Title: {{ title }}
+* Description: {{ description }}
+* Requirements: {{ requirements }}
 {% endblocktrans %}
 
-Your Badge now exists at http://badges.p2pu.org{% url badge_view badge.id %} and learners can apply for it immediately. As the Badge's creator, this badge will automatically appear on your profile.
+Your Badge is created, but that doesn't mean that people can apply for it yet. If you haven't already, then you must publish it and let the world see your creation. Publish it by pressing on the "Publish" button at http://badges.p2pu.org{% url badge_preview badge.id %}
 
-Tell the world about your spiffy Badge!
-
-Google+ - https://plus.google.com/share?url=http://badges.p2pu.org{% url badge_view badge.id %}
-
-Tweet - http://twitter.com/share?url=http://badges.p2pu.org{% url badge_view badge.id %}&text=Check out the spiffy badge I made!&via=p2pu
+As the Badge's creator, this badge will automatically appear on your profile.
 
 {% blocktrans %}
 Yours in the future of learning, 

--- a/badges/templates/emails/badge_published.html
+++ b/badges/templates/emails/badge_published.html
@@ -7,18 +7,13 @@
 Howdy!
 </p>
 <p>
-Your badge {{ badge.title }} is created. Woohoo!
-</p>
-<p>
-    Your Badge is created, but that doesn't mean that people can apply for it yet. If you haven't already, then you
-    must publish it and let the world see your creation. Publish it by pressing on the "Publish" button
-    <a href="http://badges.p2pu.org{% url badge_preview badge.id %}">here</a>.
+Your badge {{ badge.title }} is published, live, and ready-to-go.
 </p>
 <table>
     <tbody>
         <tr>
             <td>
-                <a href="http://badges.p2pu.org{% url badge_preview badge.id %}">
+                <a href="http://badges.p2pu.org{% url badge_view badge.id %}">
                     <img src="http://badges.p2pu.org{{ badge.image.url }}" width="160px"/>
                 </a>
             </td>
@@ -30,7 +25,11 @@ Your badge {{ badge.title }} is created. Woohoo!
         </tr>
     </tbody>
 </table>
-<p>As the Badge's creator, this badge will automatically appear on your profile.
+<p>
+Your Badge now exists on <a href="http://badges.p2pu.org{% url badge_view badge.id %}">badges.p2pu.org</a> and learners can apply for it immediately.
+</p>
+<p>
+Tell the world about your spiffy Badge! {% include 'emails/social_buttons.html' %}
 </p>
 
 <p>

--- a/badges/templates/emails/badge_published.txt
+++ b/badges/templates/emails/badge_published.txt
@@ -1,0 +1,22 @@
+{% load projects_tags %}{% load i18n %}{% blocktrans with title=badge.title description=badge.description|purge_content requirements=badge.requirements|html2text %}
+Howdy!
+
+Your badge {{ title }} is published, live, and ready-to-go.
+
+* Title: {{ title }}
+* Description: {{ description }}
+* Requirements: {{ requirements }}
+{% endblocktrans %}
+
+Your Badge now exists at http://badges.p2pu.org{% url badge_view badge.id %} and learners can apply for it immediately.
+
+Tell the world about your spiffy Badge!
+
+Google+ - https://plus.google.com/share?url=http://badges.p2pu.org{% url badge_view badge.id %}
+
+Tweet - http://twitter.com/share?url=http://badges.p2pu.org{% url badge_view badge.id %}&text=Check out the spiffy badge I made!&via=p2pu
+
+{% blocktrans %}
+Yours in the future of learning, 
+- The P2PU team
+{% endblocktrans %}

--- a/badges/templates/emails/badge_published_subject.txt
+++ b/badges/templates/emails/badge_published_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktrans with badge_title=badge.title%}You've just published a {{ badge_title }} Badge. Congrats!{% endblocktrans %}


### PR DESCRIPTION
The "your Badge is created and published" email was sent before the badge was published, so I have duplicated the functionality with slight tweaks in the copy.

I also had to add another template filter, since emails that are sent in text form got ugly HTML rendering which is saved in DB.
